### PR TITLE
use protected type_map from super class to support Rails 5.2 update

### DIFF
--- a/lib/armg/abstract_mysql_adapter_ext.rb
+++ b/lib/armg/abstract_mysql_adapter_ext.rb
@@ -1,5 +1,5 @@
 module Armg::AbstractMysqlAdapterExt
-  def initialize_type_map(m)
+  def initialize_type_map(m = type_map)
     super
     m.register_type %r(^geometry)i, Armg::MysqlGeometry.new
   end


### PR DESCRIPTION
rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb in version 5.2 has encapsulated  the type_map variable.
https://github.com/rails/rails/commit/2ec207520389f4a6acb393be45bc73cc3815ad76