### PR TITLE
Fix binary logging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,9 @@ Style/AccessModifierDeclarations:
   Enabled: false
 Style/Documentation:
   Enabled: false
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true

--- a/lib/armg/mysql_geometry.rb
+++ b/lib/armg/mysql_geometry.rb
@@ -6,9 +6,16 @@ module Armg
       :geometry
     end
 
+    def binary?
+      true
+    end
+
     def deserialize(value)
-      if value.is_a?(::String)
+      case value
+      when ::String
         Armg.deserializer.deserialize(value)
+      when ActiveModel::Type::Binary::Data
+        Armg.deserializer.deserialize(value.to_s)
       else
         value
       end
@@ -18,7 +25,8 @@ module Armg
       if value.nil?
         nil
       else
-        Armg.serializer.serialize(value)
+        value = Armg.serializer.serialize(value)
+        ActiveModel::Type::Binary::Data.new(value)
       end
     end
   end


### PR DESCRIPTION
Fixed the following error in SQL log:

```
Could not log "sql.active_record" event. ArgumentError: invalid byte sequence in UTF-8
```