### PR TITLE
Remove prefix length to spatial index from AR5.2

### DIFF
--- a/lib/armg/abstract_mysql_adapter_ext.rb
+++ b/lib/armg/abstract_mysql_adapter_ext.rb
@@ -12,6 +12,7 @@ module Armg
 
       is.each do |i|
         i.lengths = nil if i.type == :spatial && i.respond_to?(:lengths=)
+        i.instance_variable_set(:@lengths, nil) if i.type == :spatial && i.instance_variable_defined?(:@lengths)
       end
 
       is

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Armg, skip_create_table: true do
         create_table "geoms", force: :cascade, options: #{MysqlHelper::TABLE_OPTIONS.inspect} do |t|
           t.geometry "location", null: false
           t.string "name"
-          t.index ["location"], name: "idx_location", type: :spatial <%= ActiveRecord.gem_version >= Gem::Version.new('5.2') ? ', length: 32' : '' %>
+          t.index ["location"], name: "idx_location", type: :spatial
           t.index ["name"], name: "idx_name", length: <%= ActiveRecord.gem_version >= Gem::Version.new('5.2') ? '10' : '{ name: 10 }' %>
         end
       ERB
@@ -38,7 +38,7 @@ RSpec.describe Armg, skip_create_table: true do
       expect(@mysql_helper.dump).to match_ruby erbh(<<~ERB)
         create_table "geoms", force: :cascade, options: #{MysqlHelper::TABLE_OPTIONS.inspect} do |t|
           t.geometry "location", null: false
-          t.index ["location"], name: "idx_location", type: :spatial <%= ActiveRecord.gem_version >= Gem::Version.new('5.2') ? ', length: 32' : '' %>
+          t.index ["location"], name: "idx_location", type: :spatial
         end
       ERB
     end
@@ -50,7 +50,7 @@ RSpec.describe Armg, skip_create_table: true do
       expect(@mysql_helper.dump).to match_ruby erbh(<<~ERB)
         create_table "geoms", force: :cascade, options: #{MysqlHelper::TABLE_OPTIONS.inspect} do |t|
           t.geometry "location", null: false
-          t.index ["location"], name: "idx_location", type: :spatial <%= ActiveRecord.gem_version >= Gem::Version.new('5.2') ? ', length: 32' : '' %>
+          t.index ["location"], name: "idx_location", type: :spatial
         end
       ERB
     end


### PR DESCRIPTION
Hi, I'm a lover of this handy Gem.
Since Rails 5.2, I noticed that the spatial indexes are given a length.

The reason seems to be due to the ActiveRecord::ConnectionAdapters::IndexDefinition being changed from Struct to Class with attr_reader.

https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb

Currently, MySQL does not seem to allow to define prefix lengths for spatial indexes.