### PR TITLE
Fix: GitHub Actions does not allow nested expressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: gemfiles/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ hashFiles('ridgepole.gemspec', '**/Gemfile', '${{ matrix.gemfile }}') }}
+          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ hashFiles('ridgepole.gemspec', '**/Gemfile', matrix.gemfile) }}
           restore-keys: |
             ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.gemfile }}-
 


### PR DESCRIPTION
It seems that expressions for GitHub Actions cannot to be nested: <https://github.community/t/nested-variable-substitution/140291>. Instead, we can simply write expressions directly in an expression.