### PR TITLE
Partially support MySQL8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
           - ARMG_TEST_MYSQL_PORT=10056 ARMG_TEST_MYSQL_ENGINE=MyISAM
           - ARMG_TEST_MYSQL_PORT=10057 ARMG_TEST_MYSQL_ENGINE=MyISAM
           - ARMG_TEST_MYSQL_PORT=10057 ARMG_TEST_MYSQL_ENGINE=InnoDB
+          - ARMG_TEST_MYSQL_PORT=10080 ARMG_TEST_MYSQL_ENGINE=MyISAM
+          - ARMG_TEST_MYSQL_PORT=10080 ARMG_TEST_MYSQL_ENGINE=InnoDB
         gemfile:
           - gemfiles/ar60.gemfile
           - gemfiles/ar61.gemfile
@@ -47,6 +49,7 @@ jobs:
           function mysql_ping { mysqladmin -u root -h 127.0.0.1 -P $1 ping; }
           for i in {1..60}; do mysql_ping 10056 && break; sleep 1; done
           for i in {1..60}; do mysql_ping 10057 && break; sleep 1; done
+          for i in {1..60}; do mysql_ping 10080 && break; sleep 1; done
         env:
           BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,5 @@ Style/HashTransformValues:
   Enabled: true
 Gemspec/RequiredRubyVersion:
   Enabled: false
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Support MySQL 8.0 (with limitation) [#18](https://github.com/cookpad/armg/pull/18)
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Apply `Schemafile`
 No change
 ```
 
+## Note
+
+This gem supports only SRIDs with long-lat axis order in MySQL8.0 now.
+e.g. SRID=3857 (WGS 84 / Pseudo-Mercator -- Spherical Mercator, Google Maps, OpenStreetMap, Bing, ArcGIS, ESRI)
+
+That is, does not support SRIDs with lat-long axis order.
+e.g. SRID=4326 (WGS 84 -- WGS84 - World Geodetic System 1984, used in GPS)
+
 ## Related links
 
 * [rgeo/rgeo: Geospatial data library for Ruby](https://github.com/rgeo/rgeo)

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ Apply `Schemafile`
 No change
 ```
 
-## Note
+## Limitation on MySQL 8.0
 
-This gem supports only SRIDs with long-lat axis order in MySQL8.0 now.
+At the moment, armg gem supports only SRIDs with long-lat axis order in MySQL 8.0.
 e.g. SRID=3857 (WGS 84 / Pseudo-Mercator -- Spherical Mercator, Google Maps, OpenStreetMap, Bing, ArcGIS, ESRI)
 
-That is, does not support SRIDs with lat-long axis order.
+That is, armg does not support SRIDs with lat-long axis order.
 e.g. SRID=4326 (WGS 84 -- WGS84 - World Geodetic System 1984, used in GPS)
 
 ## Related links

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,9 @@ services:
     image: "mysql:5.7"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
+  mysql80:
+    ports:
+      - "10080:3306"
+    image: "mysql:8.0"
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=1

--- a/spec/armg_spec.rb
+++ b/spec/armg_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Armg do
 
   context 'insert' do
     specify do
-      point = wkt_parser.parse('SRID=4326;Point(-122.1 47.3)')
+      point = wkt_parser.parse('SRID=3857;Point(-122.1 47.3)')
       Geom.create!(id: 4, location: point)
       geom = Geom.find(4)
-      expect(geom.location.srid).to eq 4326
+      expect(geom.location.srid).to eq 3857
       expect(geom.location.to_s).to eq 'POINT (-122.1 47.3)'
-      rs = ActiveRecord::Base.connection.execute('SELECT LEFT(HEX(location), 8), AsText(location) FROM geoms WHERE id = 4')
-      expect(rs.to_a).to eq([['E6100000', 'POINT(-122.1 47.3)']])
+      rs = ActiveRecord::Base.connection.execute('SELECT LEFT(HEX(location), 8), ST_AsText(location) FROM geoms WHERE id = 4')
+      expect(rs.to_a).to eq([['110F0000', 'POINT(-122.1 47.3)']])
     end
   end
 
@@ -26,23 +26,23 @@ RSpec.describe Armg do
   context 'update' do
     specify do
       geom = Geom.find(3)
-      point = wkt_parser.parse('SRID=14326;Point(-122.1 147.3)')
+      point = wkt_parser.parse('SRID=3857;Point(-122.1 147.3)')
       geom.location = point
       geom.save!
       geom = Geom.find(3)
-      expect(geom.location.srid).to eq 14_326
+      expect(geom.location.srid).to eq 3857
       expect(geom.location.to_s).to eq 'POINT (-122.1 147.3)'
-      rs = ActiveRecord::Base.connection.execute('SELECT LEFT(HEX(location), 8), AsText(location) FROM geoms WHERE id = 3')
-      expect(rs.to_a).to eq([['F6370000', 'POINT(-122.1 147.3)']])
+      rs = ActiveRecord::Base.connection.execute('SELECT LEFT(HEX(location), 8), ST_AsText(location) FROM geoms WHERE id = 3')
+      expect(rs.to_a).to eq([['110F0000', 'POINT(-122.1 147.3)']])
     end
   end
 
   context 'select' do
     specify do
       {
-        1 => ['POINT (1.0 1.0)', 1245],
+        1 => ['POINT (1.0 1.0)', 3857],
         2 => ['LINESTRING (0.0 0.0, 1.0 1.0, 2.0 2.0)', 0],
-        3 => ['POLYGON ((0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0, 0.0 0.0), (5.0 5.0, 7.0 5.0, 7.0 7.0, 5.0 7.0, 5.0 5.0))', 5678]
+        3 => ['POLYGON ((0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0, 0.0 0.0), (5.0 5.0, 7.0 5.0, 7.0 7.0, 5.0 7.0, 5.0 5.0))', 3857]
       }.each do |record_id, (wkt, srid)|
         geom = Geom.find(record_id)
         expect(geom.location.srid).to eq srid

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Armg, skip_create_table: true do
+  let(:table_options) do
+    if ActiveRecord.gem_version < Gem::Version.new('6.1')
+      "options: \"#{MysqlHelper::TABLE_OPTIONS}\""
+    elsif MysqlHelper::MYSQL_ENGINE == 'InnoDB'
+      'charset: "utf8mb4", collation: "utf8mb4_bin"'
+    else
+      "charset: \"utf8mb4\", collation: \"utf8mb4_bin\", options: \"ENGINE=#{MysqlHelper::MYSQL_ENGINE}\""
+    end
+  end
+
   context 'create table' do
     specify do
       ActiveRecord::Migration.create_table :geoms, options: MysqlHelper::TABLE_OPTIONS do |t|
@@ -14,7 +24,7 @@ RSpec.describe Armg, skip_create_table: true do
       schema.sub!(', using: :btree', '') # for Active Record 5.0
 
       expect(schema).to match_ruby erbh(<<-ERB)
-        create_table "geoms", force: :cascade <%= MysqlHelper::TABLE_OPTIONS ? %s!, options: "#{MysqlHelper::TABLE_OPTIONS}"! : '' %> do |t|
+        create_table "geoms", #{table_options}, force: :cascade do |t|
           t.geometry "location", null: false
           t.string "name"
           t.index ["location"], name: "idx_location", type: :spatial <%= ActiveRecord.gem_version >= Gem::Version.new('5.2') ? ', length: 32' : '' %>
@@ -36,7 +46,7 @@ RSpec.describe Armg, skip_create_table: true do
       end
 
       expect(@mysql_helper.dump).to match_ruby erbh(<<~ERB)
-        create_table "geoms", force: :cascade <%= MysqlHelper::TABLE_OPTIONS ? %s!, options: "#{MysqlHelper::TABLE_OPTIONS}"! : '' %> do |t|
+        create_table "geoms", #{table_options}, force: :cascade do |t|
           t.geometry "location", null: false
           t.index ["location"], name: "idx_location", type: :spatial <%= ActiveRecord.gem_version >= Gem::Version.new('5.2') ? ', length: 32' : '' %>
         end
@@ -48,7 +58,7 @@ RSpec.describe Armg, skip_create_table: true do
       ActiveRecord::Migration.add_index :geoms, 'location', name: 'idx_location', type: :spatial
 
       expect(@mysql_helper.dump).to match_ruby erbh(<<~ERB)
-        create_table "geoms", force: :cascade <%= MysqlHelper::TABLE_OPTIONS ? %s!, options: "#{MysqlHelper::TABLE_OPTIONS}"! : '' %>  do |t|
+        create_table "geoms", #{table_options}, force: :cascade do |t|
           t.geometry "location", null: false
           t.index ["location"], name: "idx_location", type: :spatial <%= ActiveRecord.gem_version >= Gem::Version.new('5.2') ? ', length: 32' : '' %>
         end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -3,11 +3,11 @@
 RSpec.describe Armg, skip_create_table: true do
   let(:table_options) do
     if ActiveRecord.gem_version < Gem::Version.new('6.1')
-      "options: \"#{MysqlHelper::TABLE_OPTIONS}\""
+      %(options: "#{MysqlHelper::TABLE_OPTIONS}")
     elsif MysqlHelper::MYSQL_ENGINE == 'InnoDB'
-      'charset: "utf8mb4", collation: "utf8mb4_bin"'
+      %(charset: "utf8mb4", collation: "utf8mb4_bin")
     else
-      "charset: \"utf8mb4\", collation: \"utf8mb4_bin\", options: \"ENGINE=#{MysqlHelper::MYSQL_ENGINE}\""
+      %(charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=#{MysqlHelper::MYSQL_ENGINE}")
     end
   end
 

--- a/spec/mysql_helper.rb
+++ b/spec/mysql_helper.rb
@@ -6,13 +6,7 @@ class MysqlHelper
   MYSQL_USER    = ENV.fetch('ARMG_TEST_MYSQL_USER', 'root')
   MYSQL_DB      = ENV.fetch('ARMG_TEST_MYSQL_DB', 'armg_test')
   MYSQL_ENGINE  = ENV.fetch('ARMG_TEST_MYSQL_ENGINE', 'MyISAM')
-  TABLE_OPTIONS = if ActiveRecord.gem_version < Gem::Version.new('6.1.0')
-                    "ENGINE=#{MYSQL_ENGINE} DEFAULT CHARSET=utf8"
-                  elsif MYSQL_ENGINE == 'InnoDB'
-                    nil
-                  else
-                    "ENGINE=#{MYSQL_ENGINE}"
-                  end
+  TABLE_OPTIONS = "ENGINE=#{MYSQL_ENGINE} DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"
 
   def initialize
     @mysql = Mysql2::Client.new(

--- a/spec/mysql_helper.rb
+++ b/spec/mysql_helper.rb
@@ -41,9 +41,9 @@ class MysqlHelper
       t.index ['location'], name: 'idx_location', type: :spatial
     end
 
-    ActiveRecord::Base.connection.execute("INSERT INTO geoms (id, location) VALUES (1, GeomFromText('POINT(1 1)', 1245))")
-    ActiveRecord::Base.connection.execute("INSERT INTO geoms (id, location) VALUES (2, GeomFromText('LINESTRING(0 0,1 1,2 2)'))")
-    ActiveRecord::Base.connection.execute("INSERT INTO geoms (id, location) VALUES (3, GeomFromText('POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7, 5 5))', 5678))")
+    ActiveRecord::Base.connection.execute("INSERT INTO geoms (id, location) VALUES (1, ST_GeomFromText('POINT(1 1)', 3857))")
+    ActiveRecord::Base.connection.execute("INSERT INTO geoms (id, location) VALUES (2, ST_GeomFromText('LINESTRING(0 0,1 1,2 2)'))")
+    ActiveRecord::Base.connection.execute("INSERT INTO geoms (id, location) VALUES (3, ST_GeomFromText('POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7, 5 5))', 3857))")
   end
 
   private


### PR DESCRIPTION
This PR proposes partial support MySQL8.0.

MySQL8.0 has improved GIS support, and along with that, it comes some incompatibilities.
Among these incompatibilities, the problem is that some spatial functions follow OpenGIS standards about axis order.
https://dev.mysql.com/blog-archive/axis-order-in-spatial-reference-systems/

Until MySQL5.7, spatial functions assume that axis order is long-lat regardless of SRID.
But in MySQL8.0, axis order is defined by SRID.
In short, some SRIDs use long-lat order, but others use lat-long order.

Internal binary format of geometry type depends on longitude and latitude,
binary format is no longer compatible between MySQL5.7 and 8.0 with lat-long order SRIDs.
https://dev.mysql.com/doc/refman/8.0/en/gis-data-formats.html
```
mysql> select version();
+-----------+
| version() |
+-----------+
| 5.7.28    |
+-----------+
1 row in set (0.00 sec)

mysql> select hex(st_geomfromtext('point(1 0)', 3857)); -- long-lat order
+----------------------------------------------------+
| hex(st_geomfromtext('point(1 0)', 3857))           |
+----------------------------------------------------+
| 110F00000101000000000000000000F03F0000000000000000 |
+----------------------------------------------------+
1 row in set (0.00 sec)

mysql> select hex(st_geomfromtext('point(1 0)', 4326)); -- lat-long order
+----------------------------------------------------+
| hex(st_geomfromtext('point(1 0)', 4326))           |
+----------------------------------------------------+
| E61000000101000000000000000000F03F0000000000000000 |
+----------------------------------------------------+
1 row in set (0.00 sec)
```

```
mysql> select version();
+-----------+
| version() |
+-----------+
| 8.0.32    |
+-----------+
1 row in set (0.00 sec)

mysql> select hex(st_geomfromtext('point(1 0)', 3857)); -- long-lat order
+----------------------------------------------------+
| hex(st_geomfromtext('point(1 0)', 3857))           |
+----------------------------------------------------+
| 110F00000101000000000000000000F03F0000000000000000 |
+----------------------------------------------------+
1 row in set (0.00 sec)

mysql> select hex(st_geomfromtext('point(1 0)', 4326)); -- lat-long order
+----------------------------------------------------+
| hex(st_geomfromtext('point(1 0)', 4326))           |
+----------------------------------------------------+
| E610000001010000000000000000000000000000000000F03F |
+----------------------------------------------------+
1 row in set (0.00 sec)
```

In MySQL8.0, the only way to know whether the SRID is in lat-long order or long-lat is to access MySQL,
but currently this armg gem and the dependent RGeo gem do not have such mechanism.
Therefore, it is difficult to fully support MySQL8.0, so I would like to support MySQL8.0 only with SRIDs,
which is in long-lat order as before.
